### PR TITLE
Eliminada la parte que trae los productos en preventa recientes

### DIFF
--- a/includes/firebase_fetch.php
+++ b/includes/firebase_fetch.php
@@ -44,7 +44,7 @@ function getAccessToken($keyFilePath) {
     return $data['access_token'];
 }
 
-function obtenerProductosPorEstado($accessToken, $projectId, $estado, $limite = 4) {
+/*function obtenerProductosPorEstado($accessToken, $projectId, $estado, $limite = 4) {
     $url = "https://firestore.googleapis.com/v1/projects/{$projectId}/databases/(default)/documents:runQuery";
 
     $query = [
@@ -76,10 +76,10 @@ function obtenerProductosPorEstado($accessToken, $projectId, $estado, $limite = 
     $context = stream_context_create($options);
     $response = file_get_contents($url, false, $context);
     return json_decode($response, true);
-}
+}*/
 
 // Función para productos recientes (estado: Disponible o todos)
-function obtenerProductosRecientes($limite = 4) {
+function obtenerProductosRecientes($limite = 8) {
     global $accessToken, $projectId;
 
     $url = "https://firestore.googleapis.com/v1/projects/{$projectId}/databases/(default)/documents:runQuery";
@@ -133,8 +133,8 @@ function obtenerProductosRecientes($limite = 4) {
     return $productos;
 }
 
-// ✅ NUEVA FUNCIÓN: Productos en Preventa
-function obtenerProductosPreventa($limite = 4) {
+//NUEVA FUNCIÓN: Productos en Preventa
+/*function obtenerProductosPreventa($limite = 4) {
     global $accessToken, $projectId;
 
     $url = "https://firestore.googleapis.com/v1/projects/{$projectId}/databases/(default)/documents:runQuery";
@@ -193,4 +193,4 @@ function obtenerProductosPreventa($limite = 4) {
     }
 
     return $productos;
-}
+}*/

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -254,8 +254,9 @@ section.container {
 }
 
 .card-img-top {
-  height: 280px; /* O el valor que prefieras */
+  height: 340px; /* O el valor que prefieras */
   object-fit: cover;
+  object-position: center;
   border-top-left-radius: 0.5rem;
   border-top-right-radius: 0.5rem;
 }

--- a/public/index.php
+++ b/public/index.php
@@ -16,7 +16,7 @@
 <?php
 require __DIR__ . '/../includes/firebase_fetch.php';
 $recientes = obtenerProductosRecientes();
-$preventas = obtenerProductosPreventa();
+//$preventas = obtenerProductosPreventa();
 ?>
 
 <!-- Carrusel fuera de container -->
@@ -41,26 +41,9 @@ $preventas = obtenerProductosPreventa();
 
 <!-- Sección de Productos Recientes -->
 <section class="container mb-5">
+  <h2 class="text-center mb-5">Productos Recientes</h2>
   <div class="row row-cols-1 row-cols-sm-2 row-cols-md-4 g-4">
     <?php foreach ($recientes as $producto): ?>
-      <div class="col">
-        <div class="card h-100 product-card">
-          <img src="<?= htmlspecialchars($producto['imagenes'][0]) ?>" class="card-img-top" alt="<?= htmlspecialchars($producto['nombre']) ?>">
-          <div class="card-body">
-            <h5 class="product-title text-center"><?= htmlspecialchars($producto['nombre']) ?></h5>
-            <p class="product-price text-center">$<?= number_format($producto['precio'], 2) ?> MXN</p>
-          </div>
-        </div>
-      </div>
-    <?php endforeach; ?>
-  </div>
-</section>
-
-<!-- Sección de Productos en Preventa -->
-<section class="container mb-5">
-  <h2 class="text-center mb-4">Productos en Preventa</h2>
-  <div class="row row-cols-1 row-cols-sm-2 row-cols-md-4 g-4">
-    <?php foreach ($preventas as $producto): ?>
       <div class="col">
         <div class="card h-100 product-card">
           <img src="<?= htmlspecialchars($producto['imagenes'][0]) ?>" class="card-img-top" alt="<?= htmlspecialchars($producto['nombre']) ?>">


### PR DESCRIPTION
El cambio realizado fue a que por el momento hubó fallas en la consulta para traer los productos que tienen una referencia de estado 'preventa'. Asi que las funciones para esa parte se comentaron y se modifico la función que trae los productos sin ningún filtro, solo para mostrar aquellos que se vayan añadiendo a la base de datos. Se incrementó la cantidad a mostrar de **4** a **8**.

En index.php se elimino la sección destinada para mostrar las tarjetas de los productos que coincidieran con la consulta esperada. Por ahora sera una solución temporal, seguire tratando de encontrar la solución a ese problema.