### PR TITLE
Ajuste rápido: Centrar carrusel en Detalles.

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -755,6 +755,17 @@ footer {
     display: none;
   }
 
+ .carousel-container,
+  .carousel-thumbnails {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .col-md-6 {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+
   .col-md-7 {
     margin: 0 auto;
     text-align: center;


### PR DESCRIPTION
Ajuste rápido: había olvidado centrar correctamente el carrusel que aparece en la página de detalles xd.

Ahora cuando la pantalla tiene un ancho entre 768 px y 992 px, se centra correctamente en la parte superior :D